### PR TITLE
Added experiment start offset parameter in ndextract, fixed sampling …

### DIFF
--- a/trenchripper/interactive.py
+++ b/trenchripper/interactive.py
@@ -504,7 +504,9 @@ class focus_filter:
     def subsample_df(self,df,n_samples):
         ttl_rows = len(df)
         n_samples = min(n_samples,ttl_rows)
-        frac = min((n_samples/ttl_rows)*1.1,1.)
+        frac = min((n_samples/ttl_rows),1.)
+        min_frac = 1/df.map_partitions(len).compute().median()
+        frac = max(frac,min_frac*10)
         subsampled_df = df.sample(frac=frac, replace=False).compute()[:n_samples]
         return subsampled_df
 

--- a/trenchripper/ndextract.py
+++ b/trenchripper/ndextract.py
@@ -61,7 +61,7 @@ def apply_flatfield(img,flatfieldimg,darkimg):
     return outimg
 
 class hdf5_fov_extractor:
-    def __init__(self,nd2filename,headpath,tpts_per_file=100,ignore_fovmetadata=False,generate_thumbnails=True,thumbnail_rescale=0.05,register_images=False,reg_channel=None,nd2reader_override={}): #note this chunk size has a large role in downstream steps...make sure is less than 1 MB
+    def __init__(self,nd2filename,headpath,tpts_per_file=100,ignore_fovmetadata=False,generate_thumbnails=True,thumbnail_rescale=0.05,register_images=False,reg_channel=None,nd2reader_override={},experiment_start_delay_seconds=0): #note this chunk size has a large role in downstream steps...make sure is less than 1 MB
         self.nd2filename = nd2filename
         self.headpath = headpath
         self.metapath = self.headpath + "/metadata.hdf5"
@@ -75,6 +75,7 @@ class hdf5_fov_extractor:
         self.thumbnail_rescale = thumbnail_rescale
         self.register_images = register_images
         self.reg_channel = reg_channel
+        self.experiment_start_delay_seconds = experiment_start_delay_seconds
 
         self.organism = ''
         self.microscope = ''
@@ -113,6 +114,7 @@ class hdf5_fov_extractor:
         else:
             assignment_metadata = self.assignidx(exp_metadata,metadf=fov_metadata)
             assignment_metadata.astype({"t":float,"x": float,"y":float,"z":float,"File Index":int,"Image Index":int})
+            assignment_metadata = assignment_metadata.assign(t = lambda df_: df_['t']-self.experiment_start_delay_seconds)
 
         self.meta_handle.write_df("global",assignment_metadata,metadata=exp_metadata)
 


### PR DESCRIPTION
I made the following changes:

- I added the experiment start offset attribute to the `hdf5_fov_extractor` class in `ndextract.py`. This is needed to offset the timestamps when the experiment is started with a delay. It defaults to $0$. Here is how I instantiate the class in the main notebook when I needed to apply an offset of $7$ hours:
```
EXPERIMENT_START_DELAY_SECONDS = 7*3600
hdf5_extractor = tr.ndextract.hdf5_fov_extractor(
    nd2file,
    headpath,
    tpts_per_file=50,
    ignore_fovmetadata=False,
    nd2reader_override={"z_levels": [], "z_coordinates": []},
    experiment_start_delay_seconds = EXPERIMENT_START_DELAY_SECONDS
)
```
- We fixed the sampling for the focus filter preview.
- I fixed the way in which the focus filter is applied. It is performing groupby-apply with a nested function inside the `filter_trenchids()` function of the `kymograph_cluster` class.